### PR TITLE
Update documentation for `include` parameter

### DIFF
--- a/api/assets/resources.json
+++ b/api/assets/resources.json
@@ -890,7 +890,7 @@
             "name": "include",
             "collectionFormat": "multi",
             "type": "array",
-            "description": "Include a extra fields which are not in the default\nresponse body\n- 'association' includes additional HOA data\n- 'agreement' information on the listing agreement\n- 'garageSpaces' additional garage data\n- 'maintenanceExpense' data on maintenance expenses\n- 'parking' additional parking data\n- 'pool' includes an additional pool description\n- 'taxAnnualAmount' include the annual tax amount\n- 'taxYear' include the tax year data\n- 'rooms' include parameter will include\n   any additional rooms as a list.\n\nNote that your RETS vendor or MLS must provide these fields\nin their RETS data for them to be available in the API\nresponse.\n\nIn the future, fields which require an 'include' may become available\nby default.\n"
+            "description": "Include a extra fields which are not in the default response body. Available values:\n\n - `rooms`: include parameter will include any additional rooms as a list.\n\nNote that your RETS vendor or MLS must provide these\nfields in their RETS data for them to be available in the\nAPI response. In the future, fields which require an\n`include` may become available by default."
           }
         ],
         "security": [

--- a/api/simplyrets-openapi.yaml
+++ b/api/simplyrets-openapi.yaml
@@ -272,39 +272,15 @@ paths:
           name: include
           description: >
             Include a extra fields which are not in the default
+            response body. Available values:
 
-            response body
-
-            - 'association' includes additional HOA data
-
-            - 'agreement' information on the listing agreement
-
-            - 'garageSpaces' additional garage data
-
-            - 'maintenanceExpense' data on maintenance expenses
-
-            - 'parking' additional parking data
-
-            - 'pool' includes an additional pool description
-
-            - 'taxAnnualAmount' include the annual tax amount
-
-            - 'taxYear' include the tax year data
-
-            - 'rooms' include parameter will include
+            - 'rooms': include parameter will include
                any additional rooms as a list.
 
-            Note that your RETS vendor or MLS must provide these fields
-
-            in their RETS data for them to be available in the API
-
-            response.
-
-
-            In the future, fields which require an 'include' may become
-            available
-
-            by default.
+            Note that your RETS vendor or MLS must provide these
+            fields in their RETS data for them to be available in the
+            API response. In the future, fields which require an
+            'include' may become available by default.
           explode: true
           schema:
             type: array
@@ -391,24 +367,15 @@ paths:
           name: include
           description: |
             Include a extra fields which are not in the default
-            response body
-            - 'association' includes additional HOA data
-            - 'agreement' information on the listing agreement
-            - 'garageSpaces' additional garage data
-            - 'maintenanceExpense' data on maintenance expenses
-            - 'parking' additional parking data
-            - 'pool' includes an additional pool description
-            - 'taxAnnualAmount' include the annual tax amount
-            - 'taxYear' include the tax year data
-            - 'rooms' include parameter will include
+            response body. Available values:
+
+            - 'rooms': include parameter will include
                any additional rooms as a list.
 
-            Note that your RETS vendor or MLS must provide these fields
-            in their RETS data for them to be available in the API
-            response.
-
-            In the future, fields which require an 'include' may
-            become available by default.
+            Note that your RETS vendor or MLS must provide these
+            fields in their RETS data for them to be available in the
+            API response. In the future, fields which require an
+            'include' may become available by default.
           explode: true
           schema:
             type: array
@@ -499,38 +466,15 @@ paths:
           name: include
           description: >
             Include a extra fields which are not in the default
+            response body. Available values:
 
-            response body
-
-
-            - `association` includes additional HOA data
-
-            - `agreement` information on the listing agreement
-
-            - `garageSpaces` additional garage data
-
-            - `maintenanceExpense` data on maintenance expenses
-
-            - `parking` additional parking data
-
-            - `pool` includes an additional pool description
-
-            - `rooms` include parameter will include
+            - 'rooms': include parameter will include
                any additional rooms as a list.
 
-            Note that your RETS vendor or MLS must provide these fields
-
-            in their RETS data for them to be available with valid data
-
-            in the API response. If your MLS does not offer these fields,
-
-            they will contain 'null'.
-
-
-            In the future, fields which require an 'include' may become
-            available
-
-            by default.
+            Note that your RETS vendor or MLS must provide these
+            fields in their RETS data for them to be available in the
+            API response. In the future, fields which require an
+            'include' may become available by default.
           explode: true
           schema:
             type: array
@@ -1117,39 +1061,15 @@ paths:
           name: include
           description: >
             Include a extra fields which are not in the default
+            response body. Available values:
 
-            response body
-
-            - 'association' includes additional HOA data
-
-            - 'agreement' information on the listing agreement
-
-            - 'garageSpaces' additional garage data
-
-            - 'maintenanceExpense' data on maintenance expenses
-
-            - 'parking' additional parking data
-
-            - 'pool' includes an additional pool description
-
-            - 'taxAnnualAmount' include the annual tax amount
-
-            - 'taxYear' include the tax year data
-
-            - 'rooms' include parameter will include
+            - 'rooms': include parameter will include
                any additional rooms as a list.
 
-            Note that your RETS vendor or MLS must provide these fields
-
-            in their RETS data for them to be available in the API
-
-            response.
-
-
-            In the future, fields which require an 'include' may become
-            available
-
-            by default.
+            Note that your RETS vendor or MLS must provide these
+            fields in their RETS data for them to be available in the
+            API response. In the future, fields which require an
+            'include' may become available by default.
           explode: true
           schema:
             type: array

--- a/api/simplyrets-swagger.yaml
+++ b/api/simplyrets-swagger.yaml
@@ -952,24 +952,15 @@ paths:
         type: array
         description: |
           Include a extra fields which are not in the default
-          response body
-          - 'association' includes additional HOA data
-          - 'agreement' information on the listing agreement
-          - 'garageSpaces' additional garage data
-          - 'maintenanceExpense' data on maintenance expenses
-          - 'parking' additional parking data
-          - 'pool' includes an additional pool description
-          - 'taxAnnualAmount' include the annual tax amount
-          - 'taxYear' include the tax year data
-          - 'rooms' include parameter will include
+          response body. Available values:
+
+          - 'rooms': include parameter will include
              any additional rooms as a list.
 
-          Note that your RETS vendor or MLS must provide these fields
-          in their RETS data for them to be available in the API
-          response.
-
-          In the future, fields which require an 'include' may become available
-          by default.
+          Note that your RETS vendor or MLS must provide these
+          fields in their RETS data for them to be available in the
+          API response. In the future, fields which require an
+          'include' may become available by default.
       security:
         - basicAuth: []
       description: 'This is the main endpoint for accessing openhouses.'
@@ -1023,24 +1014,15 @@ paths:
         type: array
         description: |
           Include a extra fields which are not in the default
-          response body
-          - 'association' includes additional HOA data
-          - 'agreement' information on the listing agreement
-          - 'garageSpaces' additional garage data
-          - 'maintenanceExpense' data on maintenance expenses
-          - 'parking' additional parking data
-          - 'pool' includes an additional pool description
-          - 'taxAnnualAmount' include the annual tax amount
-          - 'taxYear' include the tax year data
-          - 'rooms' include parameter will include
+          response body. Available values:
+
+          - 'rooms': include parameter will include
              any additional rooms as a list.
 
-          Note that your RETS vendor or MLS must provide these fields
-          in their RETS data for them to be available in the API
-          response.
-
-          In the future, fields which require an 'include' may
-          become available by default.
+          Note that your RETS vendor or MLS must provide these
+          fields in their RETS data for them to be available in the
+          API response. In the future, fields which require an
+          'include' may become available by default.
       security:
         - basicAuth: []
       description: 'Use this endpoint for accessing a single OpenHouse.'
@@ -1106,24 +1088,15 @@ paths:
           - rooms
         description: |
           Include a extra fields which are not in the default
-          response body
+          response body. Available values:
 
-          - `association` includes additional HOA data
-          - `agreement` information on the listing agreement
-          - `garageSpaces` additional garage data
-          - `maintenanceExpense` data on maintenance expenses
-          - `parking` additional parking data
-          - `pool` includes an additional pool description
-          - `rooms` include parameter will include
+          - 'rooms': include parameter will include
              any additional rooms as a list.
 
-          Note that your RETS vendor or MLS must provide these fields
-          in their RETS data for them to be available with valid data
-          in the API response. If your MLS does not offer these fields,
-          they will contain 'null'.
-
-          In the future, fields which require an 'include' may become available
-          by default.
+          Note that your RETS vendor or MLS must provide these
+          fields in their RETS data for them to be available in the
+          API response. In the future, fields which require an
+          'include' may become available by default.
       security:
         - basicAuth: []
       description: |
@@ -1570,24 +1543,15 @@ paths:
           - taxAnnualAmount
         description: |
           Include a extra fields which are not in the default
-          response body
-          - 'association' includes additional HOA data
-          - 'agreement' information on the listing agreement
-          - 'garageSpaces' additional garage data
-          - 'maintenanceExpense' data on maintenance expenses
-          - 'parking' additional parking data
-          - 'pool' includes an additional pool description
-          - 'taxAnnualAmount' include the annual tax amount
-          - 'taxYear' include the tax year data
-          - 'rooms' include parameter will include
+          response body. Available values:
+
+          - 'rooms': include parameter will include
              any additional rooms as a list.
 
-          Note that your RETS vendor or MLS must provide these fields
-          in their RETS data for them to be available in the API
-          response.
-
-          In the future, fields which require an 'include' may become available
-          by default.
+          Note that your RETS vendor or MLS must provide these
+          fields in their RETS data for them to be available in the
+          API response. In the future, fields which require an
+          'include' may become available by default.
       - required: false
         in: query
         name: sort


### PR DESCRIPTION
This updates the description for the `include` parameter to not mention deprecated values (where the fields are now available in the default response).

These fields have been in the default response for a very long time, so I don't think we need to mention them in our docs anymore.

We get a lot of queries to Support where people are enumerating all possible values even though the fields are already available, so this simplifies it for everyone.