### PR TITLE
Add documentation for /agents and /agents/{agentKey} API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,11 @@ documentation, examples, and help topics. Browse the links below:
 <!-- Not sure why the below links don't work with a nested base_url -->
 - [API documentation]({{ "/api/index.html" | relative_url }})
   - [`/properties`]({{ "/api/index.html#!/default/get_properties" | relative_url }})
+  - [`/properties/{mlsId}`]({{ "/api/index.html#!/default/get_properties_mlsId" | relative_url }})
   - [`/openhouses`]({{ "/api/index.html#!/default/get_openhouses" | relative_url }})
+  - [`/openhouses/{openHouseKey}`]({{ "/api/index.html#!/default/get_properties_openHouseKey" | relative_url }})
+  - [`/agents`]({{ "/api/index.html#!/default/get_agents" | relative_url }})
+  - [`/agents/{agentKey}`]({{ "/api/index.html#!/default/get_agents_agentKey" | relative_url }})
 - [Live example](http://maxavenue.com/homes-for-sale/)
 - [API help topics](#topics)
 

--- a/api/assets/resources.json
+++ b/api/assets/resources.json
@@ -546,6 +546,36 @@
         }
       }
     },
+    "SingleAgent": {
+      "type": "object",
+      "description": "Agent Information from the Agents API",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The MLS unique system key for this entity."
+        },
+        "agentId": {
+          "type": "string",
+          "description": "The well-known MLS ID for an entity."
+        },
+        "agentKey": {
+          "type": "string",
+          "description": "The **SimplyRETS unique ID** for an entity. This number will not be familiar."
+        },
+        "firstName": {
+          "type": "string",
+          "description": "Agent first name"
+        },
+        "lastName": {
+          "type": "string",
+          "description": "Agent last name"
+        },
+        "contact": {
+          "$ref": "#/definitions/ContactInformation",
+          "description": "Agent contact information. This is only present in an API response when your RETS feed contains agent contact information Thus, **contact information is not available for all RETS Vendors.**"
+        }
+      }
+    },
     "School": {
       "type": "object",
       "description": "RETS School Data",
@@ -1553,6 +1583,132 @@
           }
         ],
         "description": "This is the main endpoint for accessing your properties. View\nall of the available query parameters and make requests below!\nThe API uses Basic Authentication, which most HTTP libraries\nwill handle for you. To use the test data (which is what this\npages uses), you can use the api key `simplyrets` and secret\n`simplyrets`. Note that these test listings are not live RETS\nlistings but the data, query parameters, and response bodies\nwill all work the same.\n"
+      }
+    },
+    "/agents": {
+      "get": {
+        "summary": "The SimplyRETS Agents API",
+        "responses": {
+          "403": {
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "description": "Will send `Authorization Required`."
+          },
+          "400": {
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "description": "Will send `Bad Request`."
+          },
+          "429": {
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "description": "Will send `Too Many Requests`. Please see our Service\nLevel Agreement for more information on Request Rates and\nAcceptable Use.\n"
+          },
+          "200": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SingleAgent"
+              }
+            },
+            "description": "Will send `Authenticated` if authentication is succesful,\notherwise it will send `Unauthorized`\n"
+          },
+          "500": {
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "description": "Will send `Internal Server Error`."
+          },
+          "401": {
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "description": "Will send `Authentication Required`."
+          }
+        },
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "type": "number",
+            "required": false,
+            "description": "The maximum number of agent entities to return per query."
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "type": "number",
+            "required": false,
+            "description": "Return agent entities starting after the _n_th entry."
+          }
+        ],
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ],
+        "description": "The Agents API gives you access to the agent specific information from your MLS. You can use this data to augment the information available from the [Listings API](/api/index.html#!/default/get_properties), build a directory of agents, and more. \n\n Note that this API is available as an [addon to any other plan](https://simplyrets.com/#home-pricing)."
+      }
+    },
+    "/agents/{agentKey}": {
+      "get": {
+        "summary": "Single Agent Endpoint",
+        "responses": {
+          "403": {
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "description": "Will send `Authorization Required`."
+          },
+          "400": {
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "description": "Will send `Bad Request`."
+          },
+          "429": {
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "description": "Will send `Too Many Requests`. Please see our Service\nLevel Agreement for more information on Request Rates and\nAcceptable Use.\n"
+          },
+          "200": {
+            "schema": {
+              "$ref": "#/definitions/SingleAgent"
+            },
+            "description": "Will send `Authenticated` if authentication is succesful,\notherwise it will send `Unauthorized`\n"
+          },
+          "500": {
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "description": "Will send `Internal Server Error`."
+          },
+          "401": {
+            "schema": {
+              "$ref": "#/definitions/Error"
+            },
+            "description": "Will send `Authentication Required`."
+          }
+        },
+        "parameters": [
+          {
+            "name": "agentKey",
+            "in": "path",
+            "type": "string",
+            "required": true,
+            "description": "The `agentKey` value for an agent. Generally, you will get this value from the [Agents API](/api/index.html#!/default/get_agents) or will have it stored if you are keeping a copy of the data locally."
+          }
+        ],
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ],
+        "description": "The Single Agent Endpoint gives you a way to query the API for _a specific agent entity_. If you know the `agentKey` value and only need data for this one agent entity, this endpoint will have better performance and transmit less data than the [Agents API](/api/index.html#!/default/get_agents).\n\n Note that this API is available as an [addon to any other plan](https://simplyrets.com/services)."
       }
     }
   }

--- a/api/simplyrets-openapi.yaml
+++ b/api/simplyrets-openapi.yaml
@@ -1855,6 +1855,33 @@ components:
           type: string
           description: Well known Agent MLS number or id.
           nullable: true
+    SingleAgent:
+      type: object
+      description: Agent Information from the Agents API
+      properties:
+        id:
+          type: string
+          description: The MLS unique system key for this entity.
+        agentId:
+          type: string
+          description: The well-known MLS ID for an entity.
+        agentKey:
+          type: string
+          description: |
+            The **SimplyRETS unique ID** for an entity. This number
+            will not be familiar.
+        firstName:
+          type: string
+          description: Agent first name.
+          nullable: true
+        lastName:
+          type: string
+          description: Agent last name.
+          nullable: true
+        contact:
+          "$ref": "#/definitions/ContactInformation"
+          description: Well known Agent MLS number or id.
+          nullable: true
     School:
       type: object
       description: RETS School Data
@@ -2123,3 +2150,187 @@ components:
           type: string
           description: Any extra amenities granted by the HOA
           nullable: true
+  '/agents':
+    get:
+      summary: The SimplyRETS Agents API
+      responses:
+        '200':
+          description: |
+            Will send `Authenticated` if authentication is succesful,
+            otherwise it will send `Unauthorized`
+          content:
+            application/json:
+              schema:
+                type: "array"
+                items:
+                  $ref: '#/components/schemas/SingleAgent'
+            application/vnd.simplyrets-v0.1+json:
+              schema:
+                type: "array"
+                items:
+                  $ref: '#/components/schemas/SingleAgent'
+        '400':
+          description: Will send `Bad Request`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/vnd.simplyrets-v0.1+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Will send `Authentication Required`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/vnd.simplyrets-v0.1+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Will send `Authorization Required`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/vnd.simplyrets-v0.1+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: |
+            Will send `Too Many Requests`. Please see our Service
+            Level Agreement for more information on Request Rates and
+            Acceptable Use.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/vnd.simplyrets-v0.1+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Will send `Internal Server Error`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/vnd.simplyrets-v0.1+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            default: 20
+          description: |
+            The maximum number of agent entities to return per query.
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            default: 0
+          description: |
+            Return agent entities starting after the _n_th entry. Used
+            for paginating through pages in the API.
+      security:
+        - basicAuth: []
+      description: |
+        The Agents API gives you access to the agent specific
+        information from your MLS. You can use this data to augment
+        the information available from the
+        [Listings API](/api/index.html#!/default/get_properties),
+        build a directory of agents, and more.
+
+        Note that this API is available as an
+        [addon to any other plan](https://simplyrets.com/#home-pricing).
+  '/agents/{agentKey}':
+    get:
+      summary: Single Agent Endpoint
+      responses:
+        '200':
+          description: |
+            Will send `Authenticated` if authentication is succesful,
+            otherwise it will send `Unauthorized`
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SingleAgent'
+            application/vnd.simplyrets-v0.1+json:
+              schema:
+                $ref: '#/components/schemas/SingleAgent'
+        '400':
+          description: Will send `Bad Request`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/vnd.simplyrets-v0.1+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Will send `Authentication Required`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/vnd.simplyrets-v0.1+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Will send `Authorization Required`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/vnd.simplyrets-v0.1+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: |
+            Will send `Too Many Requests`. Please see our Service
+            Level Agreement for more information on Request Rates and
+            Acceptable Use.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/vnd.simplyrets-v0.1+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Will send `Internal Server Error`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+            application/vnd.simplyrets-v0.1+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+      parameters:
+        - name: agentKey
+          in: path
+          required: true
+          schema:
+            type: string
+          description: |
+            "The `agentKey` value for an agent. Generally, you will
+            get this value from the
+            [Agents API](/api/index.html#!/default/get_agents) or will
+            have it stored if you are keeping a copy of the data
+            locally.
+      security:
+        - basicAuth: []
+      description: |
+        The Single Agent Endpoint gives you a way to query the API for
+        _a specific agent entity_. If you know the `agentKey` value
+        and only need data for this one agent entity, this endpoint
+        will have better performance and transmit less data than the
+        [Agents API](/api/index.html#!/default/get_agents).
+
+        Note that this API is available as an
+        [addon to any other plan](https://simplyrets.com/services).

--- a/api/simplyrets-swagger.yaml
+++ b/api/simplyrets-swagger.yaml
@@ -617,6 +617,29 @@ definitions:
       id:
         type: string
         description: Well known Agent MLS number or id.
+  SingleAgent:
+    type: object
+    description: Agent Information from the Agents API
+    properties:
+      id:
+        type: string
+        description: The MLS unique system key for this entity.
+      agentId:
+        type: string
+        description: The well-known MLS ID for an entity.
+      agentKey:
+        type: string
+        description: |
+          The **SimplyRETS unique ID** for an entity. This number will not be familiar.
+      firstName:
+        type: string
+        description: Agent first name.
+      lastName:
+        type: string
+        description: Agent last name.
+      contact:
+        "$ref": "#/definitions/ContactInformation"
+        description: Well known Agent MLS number or id.
   School:
     type: object
     description: RETS School Data
@@ -1737,3 +1760,121 @@ paths:
         `simplyrets`. Note that these test listings are not live RETS
         listings but the data, query parameters, and response bodies
         will all work the same.
+  "/agents":
+    get:
+      summary: The SimplyRETS Agents API
+      responses:
+        '403':
+          schema:
+            "$ref": "#/definitions/Error"
+          description: Will send `Authorization Required`.
+        '400':
+          schema:
+            "$ref": "#/definitions/Error"
+          description: Will send `Bad Request`.
+        '429':
+          schema:
+            "$ref": "#/definitions/Error"
+          description: |
+            Will send `Too Many Requests`. Please see our Service
+            Level Agreement for more information on Request Rates and
+            Acceptable Use.
+        '200':
+          schema:
+            type: "array"
+            items:
+              "$ref": "#/definitions/SingleAgent"
+          description: |
+            Will send `Authenticated` if authentication is succesful,
+            otherwise it will send `Unauthorized`
+        '500':
+          schema:
+            "$ref": "#/definitions/Error"
+          description: Will send `Internal Server Error`.
+        '401':
+          schema:
+            "$ref": "#/definitions/Error"
+          description: Will send `Authentication Required`.
+      parameters:
+        - name: limit
+          in: query
+          type: integer
+          format: int64
+          default: 20
+          required: false
+          description: |
+            The maximum number of agent entities to return per query.
+        - name: limit
+          in: query
+          type: integer
+          format: int64
+          required: false
+          description: |
+            Return agent entities starting after the _n_th entry. Used
+            for paginating through pages in the API.
+      security:
+        - basicAuth: []
+      description: |
+        The Agents API gives you access to the agent specific
+        information from your MLS. You can use this data to augment
+        the information available from the
+        [Listings API](/api/index.html#!/default/get_properties),
+        build a directory of agents, and more.
+
+        Note that this API is available as an
+        [addon to any other plan](https://simplyrets.com/#home-pricing).
+  "/agents/{agentKey}":
+    get:
+      summary: Single Agent Endpoint
+      responses:
+        '403':
+          schema:
+            "$ref": "#/definitions/Error"
+          description: Will send `Authorization Required`.
+        '400':
+          schema:
+            "$ref": "#/definitions/Error"
+          description: Will send `Bad Request`.
+        '429':
+          schema:
+            "$ref": "#/definitions/Error"
+          description: |
+            Will send `Too Many Requests`. Please see our Service
+            Level Agreement for more information on Request Rates and
+            Acceptable Use.
+        '200':
+          schema:
+            "$ref": "#/definitions/SingleAgent"
+          description: |
+            Will send `Authenticated` if authentication is succesful,
+            otherwise it will send `Unauthorized`
+        '500':
+          schema:
+            "$ref": "#/definitions/Error"
+          description: Will send `Internal Server Error`.
+        '401':
+          schema:
+            "$ref": "#/definitions/Error"
+          description: Will send `Authentication Required`.
+      parameters:
+        - name: agentKey
+          in: path
+          type: string
+          required: true
+          description: |
+            "The `agentKey` value for an agent. Generally, you will
+            get this value from the
+            [Agents API](/api/index.html#!/default/get_agents) or will
+            have it stored if you are keeping a copy of the data
+            locally.
+      security:
+        - basicAuth: []
+      description: |
+        The Single Agent Endpoint gives you a way to query the API for
+        _a specific agent entity_. If you know the `agentKey` value
+        and only need data for this one agent entity, this endpoint
+        will have better performance and transmit less data than the
+        [Agents API](/api/index.html#!/default/get_agents).
+
+        Note that this API is available as an
+        [addon to any other plan](https://simplyrets.com/services).


### PR DESCRIPTION
Before merging, I want to review the changes for:

- [ ] Make sure all the field/parameter names and descriptions are correct
- [ ] Add this information to the `/api/simplyrets-openapi.yaml` and `/api/simplyrets-swagger.yaml` specs.
- [ ] Add a section for the Agents API to the [SimplyRETS services page](https://simplyrets.com/services)